### PR TITLE
stronger checking for the number of args provided

### DIFF
--- a/src/upgrade-to-ses3.sh
+++ b/src/upgrade-to-ses3.sh
@@ -158,7 +158,7 @@ get_permission () {
 run_func () {
     if [ "$#" -ne 4 ]
     then
-        out_err "$FUNCNAME: Too few arguments. Provide four"
+        out_err "$FUNCNAME: Invalid number of arguments. Please provide four."
         exit 1
     fi
 


### PR DESCRIPTION
using -ne rather than -le is more correct if the number of args is static.
