### PR TITLE
run_func: replace if statement with boolean expression

### DIFF
--- a/src/upgrade-to-ses3.sh
+++ b/src/upgrade-to-ses3.sh
@@ -161,11 +161,8 @@ get_permission () {
 # If empty $msg parameter passed, we will use the get_permission() default.
 # If empty $desc parameter passed, no function description will be output.
 run_func () {
-    if [ "$#" -ne 4 ]
-    then
-        out_err "$FUNCNAME: Invalid number of arguments. Please provide four."
-        exit "$failure"
-    fi
+    # assert that we have four arguments - no more, no less!
+    [[ "$#" -ne 4 ]] && out_err "$FUNCNAME: Invalid number of arguments. Please provide four." && abort
 
     local func=$1
     shift


### PR DESCRIPTION
This if statement is basically an assert, so it's nice to have it on a single
line. Also, abort immediately (like in a real assert) instead of returning a
value.

Signed-off-by: Nathan Cutler ncutler@suse.com
