### PR TITLE
Refrain from touching CRUSH tunables (bsc#980683)

### DIFF
--- a/src/upgrade-to-ses3.sh
+++ b/src/upgrade-to-ses3.sh
@@ -273,14 +273,6 @@ running as this user. Please terminate any such processes."
 # ------------------------------------------------------------------------------
 # Operations
 # ------------------------------------------------------------------------------
-set_crush_tunables () {
-    # TODO: Preflight maybe should include checking if the cluster is up?
-    ceph --version &>/dev/null || return "$skipped"
-    get_permission || return "$?"
-
-    ceph osd crush tunables optimal || return "$failure"
-}
-
 stop_ceph_daemons () {
     # TODO: Perform pre-flight checks
     get_permission || return "$?"
@@ -438,13 +430,6 @@ finish () {
     :
 }
 
-upgrade_funcs+=("set_crush_tunables")
-upgrade_func_descs+=(
-"Set CRUSH tunables
-==================
-This will set OSD CRUSH tunables to optimal. WARNING: if you have customized
-tunables, select \"No\" at the prompt."
-)
 upgrade_funcs+=("stop_ceph_daemons")
 upgrade_func_descs+=(
 "Stop Ceph Daemons


### PR DESCRIPTION
While the default CRUSH tunables in SES2.1 are bobtail and need to be changed
at some point before (or after) upgrading to SES3, the upgrade script is not
the place to do this.

Any change in the tunables potentially causes lots of data movement.  Also,
even on a small cluster you only run "ceph osd crush tunables optimal" once,
whereas in this case we were contemplating running it on every node.

Fixes: #8
Signed-off-by: Nathan Cutler ncutler@suse.com
